### PR TITLE
Revamp ASR section

### DIFF
--- a/doc/asr.md
+++ b/doc/asr.md
@@ -4,41 +4,165 @@
 
 `to be done`
 
-### Projects
+Our projects are categorized into:
 
-| Project-name | Type | <div style="width:250px" /> Description | <div style="width:100px" /> Location                                                                                        | Last update (05.24) | Status | Buildable | Model reproducable ? | Comment |
-|--------------|------|-------------|-----------------------------------------------------------------------------------------------------------------------------|---------------------|--------|-----------|----------------------|---------|
-| Samrómur training | Software | Samrómur ASR is a collection of scripts, recipes, and tutorials for training an ASR using the Kaldi-ASR toolkit. | [GitHub](https://github.com/icelandic-lt/samromur-asr)                                                                      | 2 years | - | - | - | - |
-| Samrómur data collection platform | Software | Samrómur is a crowdsourcing data collection platform for icelandic. Samrómur aims to collect icelandic voice data which can be used to train voice-recognition software. Data collected via Samrómur is GDPR compliant. The dataset consists of multiple wav files containing the voice clips and the corresponding written text files along with demographic data about the speakers. | [GitHub](https://github.com/icelandic-lt/samromur)                                                                          | < 5 months | - | - | - | - |
-| Samrómur-tools | Software | This repo contains various tools made for the Samrómur data collection. The aim of this toolset is to make all work revolving around the Samrómur data processing quicker and easier. These tools enable you to gather large batches of data fast, process it and verify its quality to some extent as well. | [GitHub](https://github.com/icelandic-lt/samromur-tools)                                                                    | - | - | - | - | - |
-| Alignment and segmentation of TV/Radio | Software | Alignment and segmentation of TV/Radio | [GitHub](https://github.com/icelandic-lt/alignment-and-segmentation)                                                        | 3 years | - | - | - | No central Readme |
-| Mafia | Software | MAFIA is the acronym for Match-Finder Aligner. The MAFIA aligner is a software tool destined to automatically create ASR corpora out of speech files along with scripts reflecting what is spoken in such speech files. If the text of the scripts is not completely accurate, MAFIA will infer a transcription using automatic speech recognition. | [GitHub](https://github.com/icelandic-lt/mafia)<br>[Clarin.is](http://hdl.handle.net/20.500.12537/215)                     | 22.05 | - | - | - | - |
-| Tiro Speech Core | Software | Tiro Speech Core is a speech recognition server that implements a gRPC API. Support for REST is provided via a gRPC REST gateway. | [GitHub](https://github.com/icelandic-lt/tiro-speech-core)                                                                  | 1 years | - | - | - | - |
-| Heyra | Software | Android App for an Icelandic ASR service interfacing Tiro Speech Core over internet. The Heyra project provides three loosely coupled components, an implementation of Android's speech recognition interface, an intent handler activity for speech recognition actions from other applications and an input method service (i.e. virtual keyboard). | [GitHub](https://github.com/icelandic-lt/heyra)                                                                             | - | - | - | - | - |
-| ASR Models | Software | Kaldi recipes for voice control and question answering systems for Icelandic. ASR language models, the training data and all code used to generate the data and create the models | [GitHub](https://github.com/icelandic-lt/asr_voice_contral_qa.git)<br>[Clarin.is](http://hdl.handle.net/20.500.12537/295)   | - | - | - | YES | Copied to GitHub, because of the many source code references, but NO models available. |
-| LM-IS-Forms | Software | Voice control and question answering. Generate data to create language models for common form fields in Icelandic | [GitHub](https://github.com/icelandic-lt/lm-is-forms)                                                                       | 2 years | - | - | - | - |
-| Model creation recipes | Software | Voice control and question answering. Recepies for creating Kaldi language models from a few data sources for voice control and question answering systems. Voice control refers to a one-way communication between human and system with the aim of soliciting an action. | [GitHub](https://github.com/icelandic-lt/asr_create_models)                                                                 | 2 years | - | - | - | - |
-| Punctuation prediction | Software | Support tools for punctuation prediction for ASR output. A Python package that punctuates Icelandic text. The input data is unpunctuated text and punctuated text is returned. The user can choose between two punctuation models, a BERT-based Transformer and a bidirectional RNN | [GitHub](https://github.com/icelandic-lt/punctuation-prediction)<br>[Clarin.is](http://hdl.handle.net/20.500.12537/52)      | 3 years | - | - | - | - |
-| Endpoint detection | Software | Example scripts for end-point detection (EPD) in audio recordings or online audio. End-point detection is necessary in longer audo recordings to chunk it into smaller units for ASR decoding. It is a necessary first step in an ASR pipeline. | [GitHub](https://github.com/icelandic-lt/end-point-detection)                                                               | - | - | - | - | - |
-| Subword perplexity tests | Software | Subword perplexity tests | [GitHub](https://github.com/icelandic-lt/subword_perplexity_tests)                                                          | 3 years | - | - | - | No Readme, no explanations for what this does. Project ID ? |
-| Speaker diarization | Software | Speaker diarization recipes for Kaldi ASR system. | [GitHub](https://github.com/icelandic-lt/kaldi-speaker-diarization)                                                         | 3 years | - | - | - | - |
-| diar-az | Software | Diarization A to Z - Kaldi to Gecko to Kaldi/corpus and back. Scripts for speaker diarization dataset creation. | [GitHub](https://github.com/icelandic-lt/diar-az)                                                                           | 4 years | - | - | - | - |
-| Samrómur Deep Speech recipe | Software | code recipe intended to show how to integrate the corpus "Samromur 21.05" [1] and the "DeepSpeech Scorer for Icelandic 22.06" [2] to create automatic speech recognition systems using the Mozilla's DeepSpeech recognize | [GitHub](https://github.com/icelandic-lt/samromur_asr)<br>[Clarin.is](http://hdl.handle.net/20.500.12537/229)               | 2 years | - | - | - | part of samromur_asr repo |
-| Samrómur NeMo recipe | Software | code recipe intended to show how to integrate the corpus "Samromur 21.05" [1] and the "6-GRAM Language Model in Icelandic for NeMo (Binary Format) 22.06 | [GitHub](https://github.com/icelandic-lt/samromur_asr)<br>[Clarin.is](http://hdl.handle.net/20.500.12537/228)               | 3 years | - | - | - | part of samromur_asr repo |
-| Deep Speech scorer for Icelandic | Model | Scorer suitable for recognizers based on the Mozilla's DeepSpeech recognizer | [Clarin.is](http://hdl.handle.net/20.500.12537/227)<br>[HuggingFace](https://huggingface.co/Icelandic-lt/deepspeech_scorer) | 22.06 | - | - | NO | KenLM Model provided, no training scripts, etc. |
-| whisper-large-icelandic-30k-1000h | Model | ASR model, based on Whisper Large v2 and on LT-program ASR corpora is the result of fine-tuning the model "openai/whisper-large" for 30,000 steps with around **1000 hours** of Icelandic data. | [HuggingFace](https://huggingface.co/language-and-voice-lab/whisper-large-icelandic-30k-steps-1000h)                        | 1 years | - | - | NO | No SIM deliverable. No training scripts, etc. |
-| whisper-large-icelandic-62640-steps-967h | Model | ASR model, based on Whisper Large v2 and on LT-program ASR corpora for 62,640 steps with **967 hours** of Icelandic data. This model was trained with different data than whisper-large-icelandic-30k-1000h.| [HuggingFace](https://huggingface.co/language-and-voice-lab/whisper-large-icelandic-62640-steps-967h)                       | 1 years | - | - | NO | No SIM deliverable. No training scripts, etc. |
-| 6GRAM_ARPA_MODEL | Model | 6-GRAM Language Model in Icelandic for Nemo is a  word level n-gram language model in binary format suitable for recognizers based on the NVIDIA-NeMo framework. | [Clarin.is](http://hdl.handle.net/20.500.12537/226)                                                                         | 22.06 | - | - | NO | no training scripts, etc. |
-| Trivia questions | Dataset | Voice control and question answering. The questions come from an online quiz game that was operated for many years. Various individuals contributed questions to the collection, which were reviewed and categorized by difficulty. | [GitHub](https://github.com/icelandic-lt/is-trivia-questions)                                                               | 2 years | - | - | - | - |
-| Málrómur | Dataset | ASR-corpus **(152 hours, 563 speakers)**. Reykjavík University and The Icelandic Centre for Language Technology collected data for an Icelandic speech corpus in collaboration with Google. Voice samples from 563 individuals were recorded with Android G1 smartphones. In total 127,286 voice samples were recorded. Of those 108,568 were considered useful and 18,718 were discarded. | [Clarin.is](http://hdl.handle.net/20.500.12537/189)                                                                         | - | - | - | - | - |
-| Samrómur | Dataset | ASR-corpus **(145 hours, 8.392 speakers)**. This is the first release of the data from the Samrómur collection. The corpus that contains 100,000 validated speech-recordings in Icelandic. | [Clarin.is](http://hdl.handle.net/20.500.12537/189)                                                                         | - | - | - | - | - |
-| Samrómur children | Dataset | ASR-corpus **(137 hours,3.175 speakers, age 4-17)**. This release of data from the Samrómur collection focuses on children. It contains more than 137.000 of validated speech recordings uttered by children in Icelandic. | [Clarin.is](http://hdl.handle.net/20.500.12537/185)                                                                         | - | - | - | - | - |
-| Samrómur queries | Dataset | ASR-corpus **(20 hours, 3.809 speakers)** This release of data from the Samrómur collection focuses on queries. It contains 17,475 of validated speech-recordings in Icelandic. | [Clarin.is](http://hdl.handle.net/20.500.12537/180)                                                                         | - | - | - | - | - |
-| Samrómur L2 | Dataset | ASR-corpus non-native speakers **(151 hours, 4.957 speakers)**. This release of data from the Samrómur collection focuses on utterances from people where Icelandic is not their native tongue. **The data is mostly UNVERIFIED**. It contains 143,031 speech-recordings in Icelandic, of which 4,957 have been verified. 42,000 utterances have been scored with marosijo, this score indicates how likely the audio is to match the transcript. | [Clarin.is](http://hdl.handle.net/20.500.12537/263)                                                                         | - | - | - | - | - |
-| Samrómur mimic | Dataset | ASR-corpus **(66.7 hours, 1.364 speakers)**. This release of data from the Samrómur collection contains utterances where the users must first listen to a TTS version of the audio before recording the utterance. **The data is UNVERIFIED**. It contains 91,408 speech-recordings in Icelandic. | [Clarin.is](http://hdl.handle.net/20.500.12537/264)                                                                         | - | - | - | - | - |
-| Samrómur, unverified | Dataset | ASR-corpus **(2233 hours, 84.164 speakers)**. This release of data from the Samrómur collection contains all the collected data not present in other releases. **The data is mostly UNVERIFIED**. It contains 2,159,314 speech-recordings in Icelandic, of which 84,161 have been verified. Ca. 700,000 utterances have been scored with marosijo, this score indicates how likely the audio is to match the transcript. | [Clarin.is](http://hdl.handle.net/20.500.12537/265)                                                                         | - | - | - | - | - |
-| Lectures, Kennslurómur | Dataset | ASR-corpus **(51 hours, 14 speakers)**. Collection of audio recordings and their corresponding segmented transcripts from class lectures recorded at Reykjavik University and the University of Iceland. | [Clarin.is](http://hdl.handle.net/20.500.12537/171)                                                                         | - | - | - | - | - |
-| Radio data, Raddrómur | Dataset | ASR -corpus **(49 hours)**. Made out of radio podcasts mostly taken from RÚV (ruv.is). Such podcasts were selected because there exist correspondig text scripts that match with certain fidelity. After automatic segmentation of the episodes, the transcriptions were inferred using the scripts along with a forced alignment technique. | [Clarin.is](http://hdl.handle.net/20.500.12537/286)                                                                         | - | - | - | - | - |
-| TV data, RÚV | Dataset | ASR -corpus **(6.75 hours, 151 speakers)**. The RUV TV set is from two talk shows and news: Kastljós (news commentary), Kiljan (literature discussions) and the prime time news (Fréttir kl. 19:00). The data contains 5880 utterances. | [Clarin.is](http://hdl.handle.net/20.500.12537/93)                                                                          | - | - | - | - | - |
-| TV data, unknown speakers, RÚV | Dataset | ASR -corpus **(281 hours)**. The RUV TV unknown speakers corpus contains TV data from six RÚV TV shows. The data contains 221,759 utterances from various unlabelled speakers. | [Clarin.is](http://hdl.handle.net/20.500.12537/191)                                                                         | - | - | - | - | - |
-| Spjallrómur | Dataset | Spjallromur is an open-source conversational speech corpus for speech technology development. The corpus is **21 hours and 20 minutes** long, with 54 total conversations, and 102 speakers. The data was collected over one year (September 2020 - September 2021) | [GitHub](https://github.com/icelandic-lt/spjallromur)                                                                       | 6 months | - | - | - | - |
+* [Datasets](#datasets): The foundation for training ASR-related models
+* [Models](#models):  A range of ASR models
+* [Training Code](#training-code): Software used to train models.
+* [Software](#software): Tools, scripts, and software for data preprocessing, running ASR models or communicate with ASR services.
+
+## Datasets
+
+### Kennslurómur, Lectures 
+
+[![CC-BY-4.0 License](https://img.shields.io/badge/License-CC--BY--4.0-blue)](https://creativecommons.org/licenses/by/4.0/)  
+**Type:** Dataset  
+**Description:** ASR-corpus (51 hours, 14 speakers). Collection of audio recordings and their corresponding segmented transcripts from class lectures recorded at Reykjavik University and the University of Iceland.  
+**Location:** [CLARIN-IS](http://hdl.handle.net/20.500.12537/171)  
+
+### Málrómur
+
+[![CC-BY-4.0 License](https://img.shields.io/badge/License-CC--BY--4.0-blue)](https://creativecommons.org/licenses/by/4.0/)  
+**Type:** Dataset  
+**Description:** ASR-corpus (152 hours, 563 speakers). Reykjavík University and The Icelandic Centre for Language Technology collected data for an Icelandic speech corpus in collaboration with Google. Voice samples from 563 individuals were recorded with Android G1 smartphones. In total 127,286 voice samples were recorded. Of those 108,568 were considered useful and 18,718 were discarded.  
+**Location:** [CLARIN-IS](http://hdl.handle.net/20.500.12537/202)  
+
+### Raddrómur, Radio data 
+
+[![CC-BY-4.0 License](https://img.shields.io/badge/License-CC--BY--4.0-blue)](https://creativecommons.org/licenses/by/4.0/)  
+**Type:** Dataset  
+**Description:** ASR-corpus (49 hours). Made out of radio podcasts mostly taken from RÚV (ruv.is). Such podcasts were selected because there exist correspondig text scripts that match with certain fidelity. After automatic segmentation of the episodes, the transcriptions were inferred using the scripts along with a forced alignment technique.  
+**Location:** [CLARIN-IS](http://hdl.handle.net/20.500.12537/286)  
+
+### Samrómur
+
+[![CC-BY-4.0 License](https://img.shields.io/badge/License-CC--BY--4.0-blue)](https://creativecommons.org/licenses/by/4.0/)  
+**Type:** Dataset  
+**Description:** ASR-corpus (145 hours, 8.392 speakers). This is the first release of the data from the Samrómur collection. The corpus that contains 100,000 validated speech-recordings in Icelandic.  
+**Location:** [CLARIN-IS](http://hdl.handle.net/20.500.12537/189)  
+
+### Samrómur children
+
+[![CC-BY-4.0 License](https://img.shields.io/badge/License-CC--BY--4.0-blue)](https://creativecommons.org/licenses/by/4.0/)  
+**Type:** Dataset  
+**Description:** ASR-corpus (137 hours, 3.175 speakers, age 4-17). This release of data from the Samrómur collection focuses on children. It contains more than 137.000 of validated speech recordings uttered by children in Icelandic.  
+**Location:** [CLARIN-IS](http://hdl.handle.net/20.500.12537/185)  
+
+### Samrómur queries
+
+[![CC-BY-4.0 License](https://img.shields.io/badge/License-CC--BY--4.0-blue)](https://creativecommons.org/licenses/by/4.0/)  
+**Type:** Dataset  
+**Description:** ASR-corpus (20 hours, 3.809 speakers) This release of data from the Samrómur collection focuses on queries. It contains 17,475 of validated speech-recordings in Icelandic.  
+**Location:** [CLARIN-IS](http://hdl.handle.net/20.500.12537/180)  
+
+### Samrómur L2
+
+[![CC-BY-4.0 License](https://img.shields.io/badge/License-CC--BY--4.0-blue)](https://creativecommons.org/licenses/by/4.0/)  
+**Type:** Dataset  
+**Description:** ASR-corpus non-native speakers (151 hours, 4.957 speakers). This release of data from the Samrómur collection focuses on utterances from people where Icelandic is not their native tongue. The data is mostly UNVERIFIED. It contains 143,031 speech-recordings in Icelandic, of which 4,957 have been verified. 42,000 utterances have been scored with marosijo, this score indicates how likely the audio is to match the transcript.  
+**Location:** [CLARIN-IS](http://hdl.handle.net/20.500.12537/263)  
+
+### Samrómur mimic
+
+[![CC-BY-4.0 License](https://img.shields.io/badge/License-CC--BY--4.0-blue)](https://creativecommons.org/licenses/by/4.0/)  
+**Type:** Dataset  
+**Description:** ASR-corpus (66.7 hours, 1.364 speakers). This release of data from the Samrómur collection contains utterances where the users must first listen to a TTS version of the audio before recording the utterance. The data is UNVERIFIED. It contains 91,408 speech-recordings in Icelandic.  
+**Location:** [CLARIN-IS](http://hdl.handle.net/20.500.12537/264)  
+
+### Samrómur, unverified
+
+[![CC-BY-4.0 License](https://img.shields.io/badge/License-CC--BY--4.0-blue)](https://creativecommons.org/licenses/by/4.0/)  
+**Type:** Dataset  
+**Description:** ASR-corpus (2233 hours, 84.164 speakers). This release of data from the Samrómur collection contains all the collected data not present in other releases. The data is mostly UNVERIFIED. It contains 2,159,314 speech-recordings in Icelandic, of which 84,161 have been verified. Ca. 700,000 utterances have been scored with marosijo, this score indicates how likely the audio is to match the transcript.  
+**Location:** [CLARIN-IS](http://hdl.handle.net/20.500.12537/265)  
+
+### Spjallrómur
+
+[![CC-BY-4.0 License](https://img.shields.io/badge/License-CC--BY--4.0-blue)](https://creativecommons.org/licenses/by/4.0/)  
+**Type:** Dataset  
+**Description:** Spjallromur is an open-source conversational speech corpus for speech technology development. The corpus is 21 hours and 20 minutes long, with 54 total conversations, and 102 speakers. The data was collected over one year (September 2020 - September 2021)  
+**Location:** [GitHub](https://github.com/icelandic-lt/spjallromur), [CLARIN-IS](http://hdl.handle.net/20.500.12537/187)
+
+### Trivia questions
+
+[![CC-BY-4.0 License](https://img.shields.io/badge/License-CC--BY--4.0-blue)](https://creativecommons.org/licenses/by/4.0/)  
+**Type:** Dataset  
+**Description:** Voice control and question answering. The questions come from an online quiz game that was operated for many years. Various individuals contributed questions to the collection, which were reviewed and categorized by difficulty.  
+**Location:** [GitHub](https://github.com/icelandic-lt/is-trivia-questions)  
+
+### TV data, RÚV
+
+[![CC-BY-4.0 License](https://img.shields.io/badge/License-CC--BY--4.0-blue)](https://creativecommons.org/licenses/by/4.0/)  
+**Type:** Dataset  
+**Description:** ASR-corpus (6.75 hours, 151 speakers). The RUV TV set is from two talk shows and news: Kastljós (news commentary), Kiljan (literature discussions) and the prime time news (Fréttir kl. 19:00). The data contains 5880 utterances.  
+**Location:** [CLARIN-IS](http://hdl.handle.net/20.500.12537/93)  
+
+### TV data, unknown speakers, RÚV
+
+[![CC-BY-4.0 License](https://img.shields.io/badge/License-CC--BY--4.0-blue)](https://creativecommons.org/licenses/by/4.0/)  
+**Type:** Dataset  
+**Description:** ASR-corpus (281 hours). The RUV TV unknown speakers corpus contains TV data from six RÚV TV shows. The data contains 221,759 utterances from various unlabelled speakers.  
+**Location:** [CLARIN-IS](http://hdl.handle.net/20.500.12537/191)  
+
+---
+
+## Models
+
+### 6GRAM_ARPA_MODEL
+
+[![CC-BY-4.0 License](https://img.shields.io/badge/License-CC--BY--4.0-blue)](https://creativecommons.org/licenses/by/4.0/)  
+**Type:** Model  
+**Description:** 6-GRAM Language Model in Icelandic for Nemo is a word level n-gram language model in binary format suitable for recognizers based on the NVIDIA-NeMo framework.  
+**Location:** [CLARIN-IS](http://hdl.handle.net/20.500.12537/226)  
+
+### Deep Speech scorer for Icelandic 22.06
+
+[![CC-BY-4.0 License](https://img.shields.io/badge/License-CC--BY--4.0-blue)](https://creativecommons.org/licenses/by/4.0/)  
+**Type:** Model  
+**Description:** Scorer suitable for recognizers based on the Mozilla's DeepSpeech recognizer  
+**Locations:** [CLARIN-IS](http://hdl.handle.net/20.500.12537/227), [HuggingFace](https://huggingface.co/Icelandic-lt/deepspeech_scorer)  
+
+### whisper-large-icelandic-30k-1000h
+
+[![CC-BY-4.0 License](https://img.shields.io/badge/License-CC--BY--4.0-blue)](https://creativecommons.org/licenses/by/4.0/)  
+**Type:** Model  
+**Description:** ASR model, based on Whisper Large v2 and on LT-program ASR corpora is the result of fine-tuning the model "openai/whisper-large" for 30,000 steps with around 1000 hours of Icelandic data.  
+**Location:** [HuggingFace](https://huggingface.co/language-and-voice-lab/whisper-large-icelandic-30k-steps-1000h)  
+
+### whisper-large-icelandic-62640-steps-967h
+
+[![CC-BY-4.0 License](https://img.shields.io/badge/License-CC--BY--4.0-blue)](https://creativecommons.org/licenses/by/4.0/)  
+**Type:** Model  
+**Description:** ASR model, based on Whisper Large v2 and on LT-program ASR corpora for 62,640 steps with 967 hours of Icelandic data. This model was trained with different data than whisper-large-icelandic-30k-1000h.  
+**Location:** [HuggingFace](https://huggingface.co/language-and-voice-lab/whisper-large-icelandic-62640-steps-967h)  
+
+---
+
+## Training Code
+
+| Training Code           | Description                                                                                                                                                                                                                                                                     | Location                                                                                                                |
+|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| ASR Voice-Control QA    | Kaldi training code for voice control and question answering systems for Icelandic ASR language models. The training data and all code used to generate the data and create the models is included.                                                                             | [GitHub](https://github.com/icelandic-lt/asr_voice_contral_qa.git), [CLARIN-IS](http://hdl.handle.net/20.500.12537/295) |
+| LM-IS-Forms             | Voice control and question answering. Data to create language models for common form fields in Icelandic                                                                                                                                                                        | [GitHub](https://github.com/icelandic-lt/lm-is-forms)                                                                   |
+| Model Creation Recipes  | Voice control and question answering. Training code for creating Kaldi language models from a few data sources for voice control and question answering systems. Voice control refers to a one-way communication between human and system with the aim of soliciting an action. | [GitHub](https://github.com/icelandic-lt/asr_create_models)                                                             |
+| Samrómur Deep Speech    | Training code  intended to show how to integrate the corpus "Samromur 21.05" [1] and the "DeepSpeech Scorer for Icelandic 22.06" [2] to create automatic speech recognition systems using the Mozilla's DeepSpeech recognize                                                    | [GitHub](https://github.com/icelandic-lt/samromur-asr/tree/master/d5_deepspeech), [CLARIN-IS](http://hdl.handle.net/20.500.12537/229)             |
+| Samrómur NeMo           | Training code intended to show how to integrate the corpus "Samromur 21.05" [1] and the "6-GRAM Language Model in Icelandic for NeMo (Binary Format) 22.06                                                                                                                      | [GitHub](https://github.com/icelandic-lt/samromur-asr/tree/master/n5_nemo), [CLARIN-IS](http://hdl.handle.net/20.500.12537/228)             |
+| Samrómur ASR            | The Samrómur ASR training repository is a collection of scripts, recipes, and tutorials for training an ASR using the Kaldi-ASR toolkit. It also includes the above 2 training scripts for DeepSpeech and NeMo training                                                         | [GitHub](https://github.com/icelandic-lt/samromur-asr)                                                                  |
+
+---
+
+## Software
+
+| Software                          | Description                                                                                                                                                                                                                                                                                                                                                                            | Location                                                                                                             |
+|-----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| Alignment and segmentation        | Alignment and segmentation of TV/Radio                                                                                                                                                                                                                                                                                                                                                 | [GitHub](https://github.com/icelandic-lt/alignment-and-segmentation)                                                 |
+| DiarAz                            | Diarization A to Z - Kaldi to Gecko to Kaldi/corpus and back. Scripts for speaker diarization dataset creation.                                                                                                                                                                                                                                                                        | [GitHub](https://github.com/icelandic-lt/diar-az)                                                                    |
+| Endpoint Detection                | Example scripts for end-point detection (EPD) in audio recordings or online audio. End-point detection is necessary in longer audo recordings to chunk it into smaller units for ASR decoding. It is a necessary first step in an ASR pipeline.                                                                                                                                        | [GitHub](https://github.com/icelandic-lt/end-point-detection)                                                        |
+| Heyra                             | Android App for an Icelandic ASR service interfacing Tiro Speech Core over internet. The Heyra project provides three loosely coupled components, an implementation of Android's speech recognition interface, an intent handler activity for speech recognition actions from other applications and an input method service (i.e. virtual keyboard).                                  | [GitHub](https://github.com/icelandic-lt/heyra)                                                                      |
+| Mafia                             | MAFIA is the acronym for Match-Finder Aligner. The MAFIA aligner is a software tool destined to automatically create ASR corpora out of speech files along with scripts reflecting what is spoken in such speech files. If the text of the scripts is not completely accurate, MAFIA will infer a transcription using automatic speech recognition.                                    | [GitHub](https://github.com/icelandic-lt/mafia), [Clarin.is](http://hdl.handle.net/20.500.12537/215)                 |
+| Punctuation Prediction            | Support tools for punctuation prediction for ASR output. A Python package that punctuates Icelandic text. The input data is unpunctuated text and punctuated text is returned. The user can choose between two punctuation models, a BERT-based Transformer and a bidirectional RNN                                                                                                    | [GitHub](https://github.com/icelandic-lt/punctuation-prediction), [Clarin.is](http://hdl.handle.net/20.500.12537/52) |
+| Samrómur Data Collection Platform | Samrómur is a crowdsourcing data collection platform for icelandic. Samrómur aims to collect icelandic voice data which can be used to train voice-recognition software. Data collected via Samrómur is GDPR compliant. The dataset consists of multiple wav files containing the voice clips and the corresponding written text files along with demographic data about the speakers. | [GitHub](https://github.com/icelandic-lt/samromur)                                                                   |
+| Samrómur Tools                    | This repo contains various tools made for the Samrómur data collection. The aim of this toolset is to make all work revolving around the Samrómur data processing quicker and easier. These tools enable you to gather large batches of data fast, process it and verify its quality to some extent as well.                                                                           | [GitHub](https://github.com/icelandic-lt/samromur-tools)                                                             |
+| Speaker Diarization               | Speaker diarization recipes for Kaldi ASR system.                                                                                                                                                                                                                                                                                                                                      | [GitHub](https://github.com/icelandic-lt/kaldi-speaker-diarization)                                                  |
+| Subword Perplexity Tests          | Subword perplexity tests                                                                                                                                                                                                                                                                                                                                                               | [GitHub](https://github.com/icelandic-lt/subword_perplexity_tests)                                                   |
+| Tiro Speech Core                  | Tiro Speech Core is a speech recognition server that implements a gRPC API. Support for REST is provided via a gRPC REST gateway.                                                                                                                                                                                                                                                      | [GitHub](https://github.com/icelandic-lt/tiro-speech-core)                                                           |


### PR DESCRIPTION
Use current TTS section as reference:

- split table into separate parts: datasets, models, training code, software
- sort projects names inside each separate part
- improve some titles and descriptions
- corrected some URL's

It's best to view the changes via the rich diff view

@rkjaran : you are welcome to fill in better Overview prosa ...